### PR TITLE
feat: refine users change log styling

### DIFF
--- a/src/controller/router.js
+++ b/src/controller/router.js
@@ -782,7 +782,7 @@ function buildUserAuditRows(audits) {
         userId: entry.user ? entry.user.id : null,
         userName: (entry.user && entry.user.name) || 'Unknown',
         field: entry.field,
-        oldValue: entry.oldValue || '—',
+        oldValue: entry.oldValue || (entry.field === 'registered' ? 'new' : '—'),
         newValue: entry.newValue || '—',
         actor: entry.actor === 'self' ? 'User (self)' : entry.actor,
         isSelf: entry.actor === 'self',

--- a/src/views/style.css
+++ b/src/views/style.css
@@ -1198,6 +1198,25 @@
     font-weight: 600;
 }
 
+/* Match the change log's badge text to the surrounding cell text (Bootstrap
+   defaults badges to 0.75em). Scoped to the log tab so the User Directory's
+   own badges are unaffected. */
+#logPane .badge {
+    --bs-badge-font-size: 1em;
+    --bs-badge-padding-y: 0.15em;
+    --bs-badge-padding-x: 0.5em;
+    font-weight: 600;
+}
+
+/* Status-value colouring in the change log's From → To column. Placed after
+   .audit-old/.audit-new so it wins on equal specificity via source order. */
+.audit-status-active { color: #20c997; }
+.audit-status-pending { color: #ffc107; }
+.audit-status-declined { color: #fd7e14; }
+.audit-status-banned { color: #dc3545; }
+.audit-status-new { color: #0d6efd; }
+.audit-status-inactive { color: #adb5bd; }
+
 .mini-stats {
     display: grid;
     gap: 1.25rem;

--- a/src/views/users.pug
+++ b/src/views/users.pug
@@ -73,11 +73,11 @@ block content
                       else
                         span= row.userName
                     td
-                      span.badge(class=row.field === 'role' ? 'text-bg-info' : (row.field === 'registered' ? 'text-bg-success' : 'text-bg-secondary'))= row.field
+                      span.badge(class=row.field === 'role' ? 'text-bg-info' : (row.field === 'registered' ? 'text-bg-success' : 'text-bg-info'))= row.field
                     td
-                      span.audit-old #{row.oldValue}
+                      span.audit-old(class=(row.field === 'status' || row.field === 'registered') ? `audit-status-${row.oldValue}` : '') #{row.oldValue}
                       span.audit-arrow(aria-hidden="true")  →
-                      span.audit-new #{row.newValue}
+                      span.audit-new(class=(row.field === 'status' || row.field === 'registered') ? `audit-status-${row.newValue}` : '') #{row.newValue}
                     td
                       if row.isSelf
                         span.badge.text-bg-dark User (self)


### PR DESCRIPTION
Polish the Status & Role Change Log on the users page:

- Make badge text match the surrounding 16px cell text (was Bootstrap's 0.75em) and trim badge padding so pills sit even with the row instead of bulging it. Scoped to #logPane so the User Directory badges are unaffected.
- Change the "Change" column status badge from secondary to info.
- Colour status values in the "From -> To" column (active green, pending yellow, declined orange, banned red, new blue, inactive grey); role changes stay uncoloured.
- Show "new" instead of the "—" placeholder as the old value for a registration audit row, so it reads "new -> active".