### PR TITLE
fix: scope message cache per channel, not per guild

### DIFF
--- a/src/clients/discordClient.js
+++ b/src/clients/discordClient.js
@@ -151,9 +151,9 @@ async function onInteractionCreate(interaction)
 
         // Run the paginated command on behalf of the user who clicked, not the
         // bot that owns the button message. interaction.message.author is the
-        // bot, so without this getGuildPart()/loadUser() key off the bot in DMs
-        // and split the alt linked-list cache across two namespaces (the first
-        // page under the user, the paged-in ones under the bot).
+        // bot, so without this getChannelScope()/loadUser() key off the bot in
+        // DMs and split the alt linked-list cache across two namespaces (the
+        // first page under the user, the paged-in ones under the bot).
         message.author = interaction.user
         message.buttonId = interaction.customId
         // attribute the next page to whoever clicked, not the button's owner.

--- a/src/controller/commands/deckCommands.js
+++ b/src/controller/commands/deckCommands.js
@@ -1,7 +1,7 @@
 const bot = require("../bot")
 const {
     cacheKeyPrefix,
-    getGuildPart,
+    getChannelScope,
     forwardCachedMessage,
     cacheSentMessage,
 } = require("../messageCache")
@@ -33,7 +33,7 @@ async function handleDeck(ctx)
     //command is lowercased, but we need the original deck code
     const command = bot.getDeckCode(message.content)
     //check if in the cache
-    const deckKey = cacheKeyPrefix + getGuildPart(message) +
+    const deckKey = cacheKeyPrefix + getChannelScope(message) +
         'deck:' + language + ':' + command
     if (await redis.exists(deckKey)) {
         const response = await redis.json.get(deckKey, '$')
@@ -93,7 +93,7 @@ async function handleAlt(ctx)
     // This keeps the linked list in one branch: the first "alt" is sent in the
     // user's language, but paged-in pages are forced to the default language by
     // resolveButtonCommand, which would otherwise split the chain across keys.
-    const cacheKey = cacheKeyPrefix + getGuildPart(message) +
+    const cacheKey = cacheKeyPrefix + getChannelScope(message) +
         'alt:' + ctx.command
     if (await redis.exists(cacheKey)) {
         const response = await redis.json.get(cacheKey, '$')
@@ -148,7 +148,7 @@ async function handleAlt(ctx)
     await cacheSentMessage(redis, cacheKey, sent, searchExp, {'next-message': null})
     // Link the previous page to this freshly-built one.
     if (offset > 0) {
-        const prevKey = cacheKeyPrefix + getGuildPart(message) +
+        const prevKey = cacheKeyPrefix + getChannelScope(message) +
             'alt:alt' + (offset - limit || '')
         if (await redis.exists(prevKey))
             await redis.json.set(prevKey, '$["next-message"]', sent.id)

--- a/src/controller/commands/searchCommand.js
+++ b/src/controller/commands/searchCommand.js
@@ -1,6 +1,6 @@
 const {
     cacheKeyPrefix,
-    getGuildPart,
+    getChannelScope,
     forwardCachedMessage,
     cacheSentMessage,
 } = require("../messageCache")
@@ -191,7 +191,7 @@ async function handleSearch(ctx)
 {
     const {message, language, command, limit, user} = ctx
     //check if in the cache
-    const cacheKey = cacheKeyPrefix + getGuildPart(message) +
+    const cacheKey = cacheKeyPrefix + getChannelScope(message) +
         language + ':' + command + limit
     if (await serveSearchCache(ctx, cacheKey)) return true
 

--- a/src/controller/commands/synonymCommands.js
+++ b/src/controller/commands/synonymCommands.js
@@ -6,7 +6,7 @@ const {
 } = require("../../tools/search")
 const {
     cacheKeyPrefix,
-    getGuildPart,
+    getChannelScope,
     forwardCachedMessage,
     cacheSentMessage,
 } = require("../messageCache")
@@ -180,7 +180,7 @@ async function handleJsonSynonym(ctx, m)
 {
     const {message, client, redis, command, user, language} = ctx
     const cacheKey =
-        cacheKeyPrefix + getGuildPart(message) + 'syn:' + command
+        cacheKeyPrefix + getChannelScope(message) + 'syn:' + command
     if (await redis.exists(cacheKey) && !m.content) {
         const cached = await redis.json.get(cacheKey, '$')
         if (await forwardCachedMessage(

--- a/src/controller/messageCache.js
+++ b/src/controller/messageCache.js
@@ -20,17 +20,31 @@ const recoverableForwardErrors = new Set([
 ])
 
 /**
+ * The cache namespace for a message, scoped to a single channel.
+ *
+ * Cached answers are re-served by forwarding the original message into the
+ * requesting channel, so the scope must be per channel, not per guild: two
+ * channels in the same server can render the same query differently (a
+ * bot-command channel gets a paginated "Next" button, a chat channel does
+ * not, and role rules can cap the attachment count per channel). A guild-wide
+ * key let whichever channel built the entry first win, forwarding its message —
+ * button and all, or missing — into every other channel.
+ *
+ * DMs have exactly one channel per user, so the channel id already identifies
+ * the conversation; the author id is kept in the prefix only to preserve the
+ * existing user_command namespace.
  *
  * @param message
  * @returns {string}
  */
-function getGuildPart(message)
+function getChannelScope(message)
 {
+    const channelPart = 'channel:' + message.channelId.toString() + ':'
     if (message.guildId) {
-        return 'guild:' + message.guildId.toString() + ':'
+        return 'guild:' + message.guildId.toString() + ':' + channelPart
     }
 
-    return 'user_command:' + message.author.id.toString() + ':'
+    return 'user_command:' + message.author.id.toString() + ':' + channelPart
 }
 
 /**
@@ -149,7 +163,7 @@ async function cacheSentMessage(redis, key, sentMessage, ttl, extra = {})
 
 module.exports = {
     cacheKeyPrefix,
-    getGuildPart,
+    getChannelScope,
     canForwardInto,
     forwardCachedMessage,
     cacheSentMessage,

--- a/tests/messageCache.test.js
+++ b/tests/messageCache.test.js
@@ -3,7 +3,36 @@
 // No DB/Redis dependency — only discord.js and the translator (local files).
 
 const {PermissionsBitField} = require('discord.js')
-const {canForwardInto, forwardCachedMessage} = require('../src/controller/messageCache')
+const {
+    canForwardInto,
+    forwardCachedMessage,
+    getChannelScope,
+} = require('../src/controller/messageCache')
+
+describe('getChannelScope', () => {
+    test('scopes a guild message to its channel, not just its guild', () => {
+        const inChatChannel = {guildId: 'g1', channelId: 'c1'}
+        const inBotCommands = {guildId: 'g1', channelId: 'c2'}
+
+        // Same guild, different channels -> different namespaces, so a message
+        // cached in one channel is never forwarded into another (which may
+        // render the same query differently, e.g. with/without a Next button).
+        expect(getChannelScope(inChatChannel))
+            .not.toBe(getChannelScope(inBotCommands))
+        expect(getChannelScope(inChatChannel)).toBe('guild:g1:channel:c1:')
+    })
+
+    test('is stable for the same guild+channel', () => {
+        const a = {guildId: 'g1', channelId: 'c1'}
+        const b = {guildId: 'g1', channelId: 'c1'}
+        expect(getChannelScope(a)).toBe(getChannelScope(b))
+    })
+
+    test('scopes a DM by author and channel', () => {
+        const dm = {channelId: 'dm1', author: {id: 'u1'}}
+        expect(getChannelScope(dm)).toBe('user_command:u1:channel:dm1:')
+    })
+})
 
 function makeTargetChannel({hasHistory = true, isDm = false} = {}) {
     return {


### PR DESCRIPTION
Cached answers are re-served by forwarding the original message into the requesting channel, so a guild-wide key let whichever channel built the entry first win — forwarding its message into every other channel. Two channels in the same server can render the same query differently (a bot-command channel gets a paginated "Next" button, a chat channel does not, role rules can cap attachments per channel), so e.g. the alt-art gallery replayed into bot-commands with no Next button.

Rename getGuildPart -> getChannelScope and append channel:<id>: to the key. Search, deck, alt gallery and synonyms all route through this one function, so they become per-channel in a single edit; the alt linked list stays within a channel.